### PR TITLE
Fix headless on macOS

### DIFF
--- a/test_convert_pig_latin
+++ b/test_convert_pig_latin
@@ -52,7 +52,7 @@ function check {
     fi
 
     if [ $USE_MARS -eq 1 ]; then
-        local s2=$(echo -e $(echo -e "$1" | java -jar $PATH_MARS nc sm $PATH_CONVERT_PIG_LATIN_S))
+        local s2=$(echo -e $(echo -e "$1" | java -Dapple.awt.UIElement=true -jar $PATH_MARS nc sm $PATH_CONVERT_PIG_LATIN_S))
         if [ "$s2" == "$2" ]
         then
             echo -e "\t${GREEN}Success${NC}: MIPS program passed."


### PR DESCRIPTION
On macOS each command used to spawn a coffee cup in the dock, stealing
focus. This commit tells Java to not do this.

Tested on DICE (over SSH) and macOS.