### PR TITLE
Do not require an X11 server when starting MARS

### DIFF
--- a/test_convert_pig_latin
+++ b/test_convert_pig_latin
@@ -52,7 +52,7 @@ function check {
     fi
 
     if [ $USE_MARS -eq 1 ]; then
-        local s2=$(echo -e $(echo -e "$1" | java -Dapple.awt.UIElement=true -jar $PATH_MARS nc sm $PATH_CONVERT_PIG_LATIN_S))
+        local s2=$(echo -e $(echo -e "$1" | DISPLAY="" java -Dapple.awt.UIElement=true -jar $PATH_MARS nc sm $PATH_CONVERT_PIG_LATIN_S))
         if [ "$s2" == "$2" ]
         then
             echo -e "\t${GREEN}Success${NC}: MIPS program passed."


### PR DESCRIPTION
This clears the DISPLAY environment variable, meaning that one does not need to be running an X11 server when running over SSH. This also reduces the wait between launching Java and MARS running one's code.

I've tested this by SSHing into a DICE machine with and without XMing running. I'm happy to test on a physical machine if needed.